### PR TITLE
Setup FOTA build tool and GitHub CI workflow

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,0 +1,35 @@
+name: Build Examples
+on:
+  # Trigger the workflow on push, but only for main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+jobs:
+  build-mock:
+    runs-on: ubuntu-latest
+    container: mbedos/mbed-os-env:latest
+    steps:
+      # Checkout the repo and download it to the runner
+      - name: Checkout
+        uses: actions/checkout@v2
+      # Run the fota build tool with mock as the option
+      - name: Build example
+        run: ./scripts/fota.sh -e=mock
+
+  build-mcuboot:
+    runs-on: ubuntu-latest
+    container: mbedos/mbed-os-env:latest
+    steps:
+      # Checkout the repo and download it to the runner
+      - name: Checkout
+        uses: actions/checkout@v2
+      # jq is a command-line JSON processor
+      - name: Install jq
+        run: sudo apt-get install jq
+      # Pipe "yes" into the script to select the appropriate option
+      # More information about this in the documentation
+      # Run the fota build tool with mcuboot as the option
+      - name: Build example
+        run: yes | ./scripts/fota.sh -e=mcuboot

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+# macOS Desktop Services Store
+.DS_Store 
+
+# Virtual environment directory
+venv/
+
+# IDE-specific directories
+.vscode/
+.idea/
+
+# Example application dependencies
+MCUboot/target/application/mbed-os-experimental-ble-services/
+MCUboot/target/application/mbed-os/
+MCUboot/target/application/mcuboot/
+MCUboot/target/bootloader/dist/
+MCUboot/target/bootloader/imgtool.egg-info/
+MCUboot/target/bootloader/mbed-os/
+MCUboot/target/bootloader/mcuboot/
+Mock/target/mbed-os-experimental-ble-services/
+Mock/target/mbed-os/
+
+# CMake build directory
+**/cmake_build
+
+# Example application build files
+MCUboot/target/application/BUILD/
+MCUboot/target/bootloader/application.hex
+MCUboot/target/bootloader/build/
+MCUboot/target/bootloader/merged.hex
+MCUboot/target/bootloader/signed_application.hex
+MCUboot/target/bootloader/signed_update.bin
+MCUboot/target/bootloader/signed_update.hex
+MCUboot/target/bootloader/signing-keys.pem
+MCUboot/target/bootloader/signing_keys.c

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+bleak==0.12.1
+cmake==3.20.5
+mbed-cli==1.10.5
+mbed-tools==7.28.1
+mercurial==5.8
+ninja==1.10.0.post2

--- a/scripts/fota.sh
+++ b/scripts/fota.sh
@@ -63,6 +63,10 @@ clean () {
   
   rm -rf "$root/venv"
 
+  # Clean example-specific files and folders
+  mock_clean "$root"
+  mcuboot_clean "$root"
+
   say success "All neat and tidy now" && exit
 }
 

--- a/scripts/fota.sh
+++ b/scripts/fota.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author's Note:
+# The fota cli tool is used to setup and build the ble fota examples in this repository. The tool takes in as
+# arguments the example, target board, mount point of the target board, and toolchain. Note that if the mount point
+# is not provided (it could be the case that an end-user is trying to build without the board connected), then the
+# target binary is not flashed. In the case of the MCUboot example, the "factory firmware" is saved and would require
+# manual transfer when the board is indeed connected. In either case, the demonstration step would be the only part
+# that requires manual intervention.
+#
+# Important: The tool assumes the target board and toolchain unless otherwise specified by the end-user. However,
+#            currently, the only board and toolchain supported are NRF52840_DK and GCC_ARM respectively.
+
+set -e
+trap 'cleanup $?' SIGINT SIGTERM ERR EXIT
+
+source scripts/utils.sh
+
+# Display a neatly formatted message on how to use this tool
+usage () {
+  cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]}") [options]
+
+  A simple cli tool to automate the setup and build process for Bluetooth-LE
+  Firmware Over the Air (FOTA) examples
+
+Options:
+  -e=, --example=TEXT             The example you are trying to setup and build.
+                                  [default: mock]
+  -t=, --toolchain=[GCC_ARM|ARM]  The toolchain you are using to build your app.
+                                  [default: GCC_ARM]
+  -b=, --board=TEXT               A build target for an Mbed-enabled device.
+                                  [default: NRF52840_DK]
+  -m=, --mount=TEXT               Path to the mount point of the target board.
+  -c, --clean                     Clean the example builds and environment
+  -h, --help                      Print this message and exit
+
+Note:
+  For now, only the NRF52840_DK board and GCC_ARM toolchain are supported. Also,
+  if a mount point isn't provided, then the target binary is not flashed.
+EOF
+  exit
+}
+
+# This function would clean up the example builds and generated files
+clean () {
+  say message "Cleaning builds and generated files..."
+  
+  rm -rf "$root/venv"
+
+  say success "All neat and tidy now" && exit
+}
+
+# Parses the options specified by the end-user and either assigns the corresponding variable or calls a function and
+# exits (i.e. in the case of help and clean). If the option is unrecognised, the function returns 1, which triggers
+# a fail that exits the tools and displays an error on stderr.
+parse_options () {
+  for i in "$@"; do
+    case $i in
+      -e=*|--example=*)   example="${i#*=}"   ; shift  ;;
+      -t=*|--toolchain=*) toolchain="${i#*=}" ; shift  ;;
+      -b=*|--board=*)     board="${i#*=}"     ; shift  ;;
+      -m=*|--mount=*)     mount="${i#*=}"     ; shift  ;;
+      -c|--clean)         clean               ;;
+      -h|--help)          usage               ;;
+      *)                  return 1            ;;
+    esac
+  done
+}
+
+# Check that the provided target board mount point is valid. If the mount point is not provided, display a short message
+# indicating that binaries will have to be flashed manually.
+valid_mount () {
+  if [[ -z $mount ]]; then
+    say note "Mount point not provided - binaries will not be flashed."
+    skip=1
+  else
+    [ -d "$mount" ] || fail "Mount point invalid" \
+                                 "Please check the path and if the board is connected" \
+                                 "Tip: Use mbed-ls to identify the mount point path"
+  fi
+}
+
+# Checks if the example is either mock or mcuboot. If more examples, are added in the future, this function would have
+# to be modified accordingly.
+valid_example () {
+  case $example in
+    mock|mcuboot) ;;
+    *) fail "Invalid example" "Supported examples - [mock|mcuboot]" ;;
+  esac
+}
+
+# Checks if the board is NRF52840_DK as it's currently the only supported board. This function will have to be modified
+# when DISCO_L475VG_IOT01A (and maybe other boards) are supported at a later point.
+valid_board () {
+  case $board in
+    NRF52840_DK) ;;
+    *) fail "Unsupported board" "The only supported board is NRF52840_DK"
+  esac
+}
+
+# Checks if the toolchain is GCC_ARM as it's the only one supported. The ARM toolchain may be supported in the future.
+valid_toolchain () {
+  case $toolchain in
+    GCC_ARM) ;;
+    *) fail "Unsupported toolchain" "The only supported toolchain is GCC_ARM"
+  esac
+}
+
+# A series of checks to make sure that the program options are valid
+check_usage () {
+  valid_mount
+  valid_example
+  valid_board
+  valid_toolchain
+}
+
+# Setups up the main virtual environment and activates it
+setup_virtualenv () {
+  if [[ -d venv ]]; then
+    say message "Using existing virtual environment venv..."
+  else
+    say message "Creating virtual environment..."
+
+    # Create the venv directory and setup the virtual environment
+    # shellcheck disable=SC2015
+    mkdir venv && python3 -m venv venv \
+      || fail "Virtual environment creation failed!" "Tip: Check your python installation!"
+  fi
+  source venv/bin/activate
+  say success "Virtual environment activated"
+}
+
+# Installs the required python dependencies silently and notify if there's any issue in the installation.
+install_requirements () {
+  say message "Installing/updating requirements silently..."
+  # shellcheck disable=SC2015
+  pip install -q --upgrade pip && pip install -q -r "$root/requirements.txt" \
+    || fail "Unable to install requirements!" "Please take a look at requirements.txt"
+  say success "General requirements installed/updated"
+}
+
+# Cleanup routine that runs when the program exits (either successfully or abruptly)
+cleanup () {
+  # If unsuccessful termination, then clean the build
+  if [[ "$1" -eq 1 ]]; then clean; fi
+}
+
+#-----------------------------------------------------------------------------------------------------------------------
+# Main Program
+#-----------------------------------------------------------------------------------------------------------------------
+main () {
+  # Default Options:
+  example="mock"
+  toolchain="GCC_ARM"
+  board="NRF52840_DK"
+  skip=0               # Skip the binary flashing if mount point is missing - Default: false
+
+  # Root directory of repository
+  root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &>/dev/null && pwd -P)
+
+  setup_formatting
+  parse_options "$@" || fail "Unrecognised option" "Please use -h or --help for usage"
+
+  check_usage
+  setup_virtualenv
+  install_requirements
+}
+
+main "$@"
+exit

--- a/scripts/fota.sh
+++ b/scripts/fota.sh
@@ -28,6 +28,8 @@ set -e
 trap 'cleanup $?' SIGINT SIGTERM ERR EXIT
 
 source scripts/utils.sh
+source scripts/mock.sh
+source scripts/mcuboot.sh
 
 # Display a neatly formatted message on how to use this tool
 usage () {
@@ -153,6 +155,16 @@ install_requirements () {
   say success "General requirements installed/updated"
 }
 
+# Call the build functions corresponding to the selected example
+# Pre: The example is valid and so are all other arguments.
+build_example () {
+  args=("$toolchain" "$board" "$mount" "$skip" "$root")
+  case $example in
+    mock)    mock_build "${args[@]}"    ;;
+    mcuboot) mcuboot_build "${args[@]}" ;;
+  esac
+}
+
 # Cleanup routine that runs when the program exits (either successfully or abruptly)
 cleanup () {
   # If unsuccessful termination, then clean the build
@@ -178,6 +190,7 @@ main () {
   check_usage
   setup_virtualenv
   install_requirements
+  build_example
 }
 
 main "$@"

--- a/scripts/mcuboot.sh
+++ b/scripts/mcuboot.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Prompt the end-user on whether they'd like the script to automatically update the application version number in the
+# mbed_app.json file. This is especially useful for the CI workflow where "yes" would be piped into the script.
+prompt_auto_update () {
+  while true; do
+    read -rp "Do you wish to auto-update the version number in application/mbed_app.json? " response
+    case $response in
+        [Yy]*) auto_update=1                          ; break ;;
+        [Nn]*) auto_update=0                          ; break ;;
+        *)     say message "Please answer yes or no." ;;
+    esac
+  done
+}
+
+# Builds the mcuboot example and flashes the binaries if a mount is provided.
+# Please refer to the commented steps for more information
+# Pre: Arguments passed here are all valid
+mcuboot_build () {
+  toolchain=$1; board=$2; mount=$3; skip=$4; root=$5
+
+  # Paths to application and bootloader
+  application=$root/mcuboot/target/application
+  bootloader=$root/mcuboot/target/bootloader
+
+  say message "Installing/updating example-specific dependencies..."
+  # 1. Install application dependencies - mbed-os (silently)
+  # shellcheck disable=SC2015
+  cd "$application" && mbed-tools deploy > /dev/null 2>&1 || \
+    fail "Unable to install application dependencies" \
+              "Please check mcuboot.lib, mbed-os.lib, and mbed-os-experimental-ble-services.lib"
+
+  # 2. Install bootloader dependencies (silently)
+  # shellcheck disable=SC2015
+  cd "$bootloader" && mbed-tools deploy > /dev/null 2>&1 || \
+    fail "Unable to install bootloader dependencies" \
+              "Please check mcuboot.lib and mbed-os.lib"
+
+  # 3. Install mbed-os python dependencies (silently)
+  pip install -q -r mbed-os/requirements.txt || \
+    fail "Unable to install mbed-os requirements" "Please take a look at mbed-os/requirements.txt"
+
+  # A short message addressing the known Click dependency conflict - this should be removed once resolved.
+  say note "Click dependency conflict" \
+           "This is a known issue and does not hinder the build process" \
+           "Refer to the documentation for more information"
+
+  # 4. Install mcuboot requirements (silently)
+  pip install -q -r mcuboot/scripts/requirements.txt || \
+    fail "Unable to install mcuboot requirements" "Please take a look at mcuboot/scripts/requirements.txt"
+
+  # 5. Run mcuboot setup script (silently)
+  python mcuboot/scripts/setup.py install > /dev/null 2>&1 || \
+    fail "MCUboot setup script failed"
+
+  say success "Example requirements installed/updated"
+  say message "Creating the signing keys and building the bootloader..."
+
+  # 6. Create the signing keys (silently)
+  # Note: This does not silence errors.
+  # shellcheck disable=SC2015
+  mcuboot/scripts/imgtool.py keygen -k signing-keys.pem -t rsa-2048 >/dev/null && \
+    mcuboot/scripts/imgtool.py getpub -k signing-keys.pem >> signing_keys.c || \
+      fail "Unable to create the signing keys"
+
+  # 7. Build the bootloader using the old mbed-cli
+  # Note: This does not silence errors
+  mbed compile -t "$toolchain" -m "$board" >/dev/null || \
+    fail "Failed to compile the bootloader" "Please check the sources"
+
+  say success "Created signing keys and built the bootloader"
+  say message "Building and signing the primary application..."
+
+  # 8. Build the primary application using the old mbed-cli
+  # Note: This does not silence errors
+  # shellcheck disable=SC2015
+  cd "$application" && mbed compile -t "$toolchain" -m "$board" >/dev/null || \
+    fail "Failed to compile the bootloader" "Please check the sources"
+
+  # shellcheck disable=SC2015
+  cp "BUILD/$board/$toolchain/application.hex" "$bootloader" && cd "$bootloader" && \
+    mcuboot/scripts/imgtool.py sign -k signing-keys.pem \
+    --align 4 -v 0.1.0 --header-size 4096 --pad-header -S 0xC0000 \
+    --pad application.hex signed_application.hex || \
+      fail "Unable to sign the primary application"
+
+  say success "Built and signed the primary application"
+  say message "Deactivating virtual environment to setup a new one..."
+  say note "PyYAML dependency conflict" \
+           "pyocd and mbed-os confict in their version requirements of PyYAML" \
+           "Refer to the documentation for more information."
+
+  # 9. Deactivate the primary virtual environment
+  deactivate
+
+  say message "Creating temporary virtual environment..."
+
+  # 10. Create a new, temporary virtual environment just for pyocd and intelhex
+  # shellcheck disable=SC2015
+  mkdir venv && python3 -m venv venv || \
+    fail "Virtual environment creation failed!" "Tip: Check your python installation!"
+
+  # 11. Activate temporary virtual environment
+  source venv/bin/activate
+
+  say success "Temporary virtual environment activated"
+  say message "Installing requirements (pyocd and intelhex) silently..."
+
+  # 12. Install requirements (pyocd and intelhex) for temporary environment (silently)
+  # shellcheck disable=SC2015
+  pip install -q --upgrade pip && pip install -q pyocd==0.30.3 intelhex==2.3.0 || \
+    fail "Unable to install temporary venv requirements" "Please check scripts/mcuboot.sh"
+
+  say success "Requirements installed/updated"
+
+  # 13. Create the factory firmware
+  hexmerge.py -o merged.hex --no-start-addr "BUILD/$board/$toolchain/bootloader.hex" signed_application.hex || \
+    fail "Unable to create factory firmware"
+
+  # 14. Flash the board with the binary (if skip is 0)
+  if [[ "$skip" -eq 0 ]]; then
+    pyocd erase --chip && cp merged.hex "$mount" \\
+      fail "Unable to flash firmware!" "Please ensure the board is connected"
+    say success "Factory firmware flashed"
+  else
+    say message "Factory firmware at $root/mcuboot/target/bootloader/merged.hex"
+  fi
+
+  # 15. Deactivate and restore virtual environment
+  deactivate && rm -rf venv && source "$root/venv/bin/activate"
+
+  # 16. Creating the update binary
+  # This involves changing the application's version number in mbed_app.json to 0.1.1 and rebuilding it, copying the
+  # hex file into the bootloader folder, signing the updated application with the RSA-2048 keys and generating the raw
+  # binary file from the signed_update.hex so that it can be transported over BLE.
+  prompt_auto_update
+
+  if [[ "$auto_update" -eq 0 ]]; then
+    # User updates the binary manually, in which case we wait for them to do so
+    say message "Please update the app version number in application/mbed_app.json" \
+                "Once done, press ENTER to continue..."
+    while read -r -n 1 key
+    do
+      # if input == ENTER key
+      [ -z "$key" ] && break
+    done
+  else
+    # Use jq to update the binary
+    # shellcheck disable=SC2015
+    cd "$application" && \
+      jq '."config"."version-number"."value" = "\"0.1.1\""' --indent 4 mbed_app.json > tmp.$$.json \
+        && mv tmp.$$.json mbed_app.json || \
+          fail "Failed in updating application/mbed_app.json" "Please check scripts/mcuboot.sh"
+  fi
+
+  say message "Creating the update binary..."
+
+  # shellcheck disable=SC2015
+  cd "$application" && mbed compile -t "$toolchain" -m "$board" >/dev/null || \
+    fail "Failed to compile the application" "Please check the sources"
+
+  # shellcheck disable=SC2015
+  cp "BUILD/$board/$toolchain/application.hex" "$bootloader" && cd "$bootloader" && \
+    mcuboot/scripts/imgtool.py sign -k signing-keys.pem \
+    --align 4 -v 0.1.1 --header-size 4096 --pad-header -S 0x55000 \
+    application.hex signed_update.hex || \
+      fail "Unable to sign the updated application"
+
+  arm-none-eabi-objcopy -I ihex -O binary signed_update.hex signed_update.bin || \
+    fail "Failed to extract binary from elf" "Tip: Check if arm-none-eabi-objcopy is in your path"
+
+  say message "Update binary at $root/mcuboot/target/bootloader/signed_update.hex"
+  say success "Build Complete" "Please refer to the documentation for demonstration instructions"
+}
+

--- a/scripts/mcuboot.sh
+++ b/scripts/mcuboot.sh
@@ -186,3 +186,20 @@ mcuboot_build () {
   say success "Build Complete" "Please refer to the documentation for demonstration instructions"
 }
 
+# Clean build files and dependencies specific to this example
+# Pre: root is valid
+mcuboot_clean () {
+  root=$1
+  application="$root/mcuboot/target/application"
+  bootloader="$root/mcuboot/target/bootloader"
+
+  # Remove generated files and folders in bootloader folder
+  rm -rf "$bootloader"/sign* "$bootloader/application.hex" "$bootloader/merged.hex"
+  rm -rf "$bootloader/build" "$bootloader/dist" "$bootloader/imgtool.egg-info"
+
+  # Remove bootloader dependencies
+  rm -rf "$bootloader/mbed-os" "$bootloader/mcuboot"
+
+  # Remove application build folder and dependencies
+  rm -rf "$application/BUILD" "$application/mbed-os" "$application/mbed-os-experimental-ble-services" "$application/mcuboot"
+}

--- a/scripts/mock.sh
+++ b/scripts/mock.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source scripts/utils.sh
+
+# Builds the mock example and flashes the binary if a mount point is provided
+# Please refer to the commented steps for more information
+# Pre: Arguments passed here are all valid
+mock_build () {
+  toolchain=$1; board=$2; mount=$3; skip=$4; root=$5
+
+  say message "Installing/updating example-specific dependencies..."
+  # 1. Install mbed-os and mbed-os experimental-ble-services (silently)
+  # shellcheck disable=SC2015
+  cd "$root/mock/target" && mbed-tools deploy > /dev/null 2>&1 || \
+    fail "Unable to install mbed-os or mbed-os-experimental-ble-services dependency"
+
+  # 2. Install mbed-os python dependencies
+  pip install -q -r mbed-os/requirements.txt || \
+    fail "Unable to install mbed-os requirements" "Please take a look at mbed-os/requirements.txt"
+
+  # A short message addressing the known Click dependency conflict - this should be removed once resolved.
+  say note "Click dependency conflict" \
+           "This is a known issue and does not hinder the build process" \
+           "Refer to the documentation for more information"
+  say success "Example requirements installed/updated"
+
+  out="cmake_build/$board/develop/$toolchain"
+  # 3. Compile the example with the target board and toolchain
+  # Note: This does not silence errors.
+  mbed-tools compile -t "$toolchain" -m "$board" >/dev/null || \
+    fail "Failed to compile the example" "Please check the sources"
+
+  # 4. Convert the output .elf executable to a .bin as it's what NRF52840_DK requires
+  arm-none-eabi-objcopy -O binary "$out/BLE_GattServer_FOTAService.elf" "$out/BLE_GattServer_FOTAService.bin" || \
+    fail "Failed to extract binary from elf" "Tip: Check if arm-none-eabi-objcopy is in your path"
+
+  # 5. Flash the board with the binary (if skip is 0)
+  # shellcheck disable=SC2015
+  if [[ "$skip" -eq 0 ]]; then
+    cp "$out/BLE_GattServer_FOTAService.bin" "$mount" || \
+      fail "Unable to flash binary!" "Please ensure the board is connected"
+    say success "Binary flashed"
+  else
+    say message "Binary at $root/mock/target/$out/BLE_GattServer_FOTAService.bin"
+  fi
+
+  say success "Build Complete" "Please refer to the documentation for demonstration instructions"
+}
+

--- a/scripts/mock.sh
+++ b/scripts/mock.sh
@@ -60,3 +60,11 @@ mock_build () {
   say success "Build Complete" "Please refer to the documentation for demonstration instructions"
 }
 
+# Clean build files and dependencies specific to this example
+# Pre: root is valid
+mock_clean () {
+  root=$1
+  rm -rf "$root/mock/target/cmake_build"
+  rm -rf "$root/mock/target/mbed-os"
+  rm -rf "$root/mock/target/mbed-os-experimental-ble-services"
+}

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Author's Note:
+# This shell script contains utility functions for use in the main fota script
+# as well as the setup and build scripts of the examples.
+
+# Constants for text formatting:
+setup_formatting () {
+  _clear='\e[0m'
+  _bold='\e[1m'
+  _red='\e[31m'
+  _green='\e[32m'
+  _yellow='\e[33m'
+}
+
+# Says (i.e. prints) a message to the console with formatting based on the selected formatting mode.
+say () {
+  case $1 in
+    error)
+      # The first line of the message is treated as the message heading and is marked in bold red along with an "ERROR:"
+      # prefix. Subsequent message lines are presented with default formatting unless otherwise formatted beforehand.
+      # All output is directed to stderr.
+      heading=${2-"ERROR"}
+      printf "%b\n" \
+             "${_bold}${_red}ERROR: $heading${_clear}" \
+             "${@:3}" >&2
+      ;;
+    success)
+      heading=${2-"SUCCESS"}
+      printf "%b\n" \
+             "${_bold}${_green}SUCCESS: $heading${_clear}" \
+             "${@:3}"
+      ;;
+    message)
+      printf "%b\n" "${@:2}"
+      ;;
+    note)
+      heading=${2-"NOTE"}
+      printf "%b\n" \
+             "${_bold}${_yellow}NOTE: $heading${_clear}" \
+             "${@:3}"
+      ;;
+    *) # Unknown error
+      ;;
+  esac
+}
+
+# Prints an error message to stderr and exits (or returns) with a code of 1
+fail () {
+  say error "$@"
+  exit 1
+}


### PR DESCRIPTION
## FOTA Build Tool
Currently, to setup the two examples ([MCUBoot](https://github.com/ARMmbed/mbed-os-example-ble/tree/fota-service-example/FOTA/MCUboot) and [Mock](https://github.com/ARMmbed/mbed-os-example-ble/tree/fota-service-example/FOTA/Mock)) for demonstration, the build instructions in their associated documentation has to be followed step-by-step. This process can be quite cumbersome and isn't entirely ideal for testing. 

Instead, this build process can be automated through a simple bash script that performs every step in the build instructions for the end-user -  as a result, the `fota.sh` cli build tool was created. The tool takes in as arguments the example, target board, mount point of target board, and toolchain.

> **Note**: If the mount point is not provided (it could be the case that an end-user is trying to build without the board connected), then the target binary is not flashed. This is especially useful for building the examples with a CI workflow. 
>
> In the case of the MCUboot example, the _"factory firmware"_ is saved and would require manual transfer when the board is indeed connected. In either case, the demonstration step would be the only part that requires manual intervention from the user. 
>
> **Important**: For now, the tool assumes the target board, toolchain, and example unless otherwise specified by the end-user. Currently, the only board and toolchain supported are NRF52840_DK and GCC_ARM respectively.

There are slight kludges with how the MCUboot and Mock examples are built with `fota.sh`. The former is a direct result of dependency conflicts between [mbed-tools](https://github.com/ARMmbed/mbed-tools), [pyocd](https://github.com/pyocd/pyOCD), and [mbed-os](https://github.com/ARMmbed/mbed-os). The latter is a result of issues with flashing the target binary to the connected board. The details of both are addressed below:

1. **Dependency Conflicts**: The difference in version requirements of the [PyYAML](https://pyyaml.org) dependency imposed by both mbed-os and pyocd led to the creation of a temporary virtual environment; this is used in the "_creating and flashing the factory firmware_" stage of the MCUboot example build process. This is a known issue and would require changes to the `requirements.txt` file in the mbed-os to resolve.\
\
Another minor conflict that doesn't hinder the build process is one between mbed-tools and mbed-os on the version requirement of the [Click](https://click.palletsprojects.com/en/8.0.x/) dependency; mbed-tools requires that the minimum version of Click to be greater than 7.1 while mbed-os requires it to be greater than 7.0. Now, the dependencies for mbed-os are installed after those of mbed-tools, which overwrites the newer version and generates a conflict. This would (again) require changes to the requirements file in the mbed-os repository to bump up the minimum version number of Click to 7.1.

2. **Target Binary Flashing**: For the Mock example, compiling with mbed-tools results in the following error:
    ```
    ERROR: Build program file (firmware) not found <path to mock example>/target/cmake_build/<target board>/develop/<toolchain>/target.hex
    ``` 
    The tool is looking for a hex file under the cmake build output whose name comes from project directory (in this case, "target"). However, the generated one is named `BLE_GattServer_FOTAService.hex`. Again, this is a known issue and has been [filed](https://github.com/ARMmbed/mbed-tools/issues/282) (282) in the mbed-tools repository by [noonfom](https://github.com/noonfom).

## GitHub CI Workflow
Currently, there is no CI workflow setup to make sure that both examples build successfully. The aim was to setup a GitHub actions workflow that uses the new CLI build tool `fota.sh` (from branch [build-process-automation](https://github.com/lambda-shuttle/mbed-os-example-ble-fota/tree/build-process-automation)) to build the examples and check for any errors; known issues (documented above) are ignored or have workarounds implemented to avoid them.

A GitHub workflow "Build Examples" was created to build the two examples (as two separate jobs). Also, this workflow uses the [mbed-os-env](https://github.com/ARMmbed/mbed-os-docker-images/tree/master/mbed-os-env) container as it bundles the GCC ARM toolchain, along with Python and CMake.  

## Other Remarks
Pull request #2 was issued from my forked repo's main branch, which saw a quite a lot of commits (67 to be exact) for development work on these two requirements - the commit history was too long to be meaningful and human readable (more information [here](https://github.com/lambda-shuttle/mbed-os-example-ble-fota/issues/9)). As a result, this new pull request is issued with the amended commit history. 

The description of this pull request was adapted from the descriptions of issues and pull requests made in my [fork](https://github.com/lambda-shuttle/mbed-os-example-ble-fota).

For the automation script, the aim was to write it in bash as it is widely available and easily maintainable. In the future, the script's functionality could be migrated into a CLI tool written in Python. 

It was not a strict requirement to run the examples on the target board using the CI workflow by means of a Raspberry Pi rig connected to an NRF52840_DK target board. However, support for this can be added later considering that the new build tool supports building the examples without providing a mount point. 