### PR TITLE
Fix MCUboot dependency paths, update workflow to use apt-get and remove /dev/null redirects

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,9 +1,5 @@
 name: Build Examples
 on:
-  # Trigger the workflow on push, but only for main
-  push:
-    branches:
-      - main
   workflow_dispatch:
   pull_request:
 jobs:
@@ -14,8 +10,11 @@ jobs:
       # Checkout the repo and download it to the runner
       - name: Checkout
         uses: actions/checkout@v2
+      # Install the venv module
       - name: Install dependencies
-        run: apt update && apt install jq python3.8-venv -y
+        run: |
+          apt-get update -y
+          apt-get install -y python3-venv
       # Run the fota build tool with mock as the option
       - name: Build example
         run: ./scripts/fota.sh -e=mock
@@ -29,7 +28,9 @@ jobs:
         uses: actions/checkout@v2
       # jq is a command-line JSON processor
       - name: Install dependencies
-        run: apt update && apt install jq python3.8-venv -y
+        run: |
+          apt-get update -y
+          apt-get install -y jq python3-venv
       # Pipe "yes" into the script to select the appropriate option
       # More information about this in the documentation
       # Run the fota build tool with mcuboot as the option

--- a/scripts/mock.sh
+++ b/scripts/mock.sh
@@ -22,12 +22,12 @@ mock_build () {
   toolchain=$1; board=$2; mount=$3; skip=$4; root=$5
 
   say message "Installing/updating example-specific dependencies..."
-  # 1. Install mbed-os and mbed-os experimental-ble-services (silently)
+  # 1. Install mbed-os and mbed-os experimental-ble-services
   # shellcheck disable=SC2015
-  cd "$root/Mock/target" && mbed-tools deploy > /dev/null 2>&1 || \
+  cd "$root/Mock/target" && mbed-tools deploy || \
     fail "Unable to install mbed-os or mbed-os-experimental-ble-services dependency"
 
-  # 2. Install mbed-os python dependencies
+  # 2. Install mbed-os python dependencies (silently)
   pip install -q -r mbed-os/requirements.txt || \
     fail "Unable to install mbed-os requirements" "Please take a look at mbed-os/requirements.txt"
 
@@ -39,8 +39,7 @@ mock_build () {
 
   out="cmake_build/$board/develop/$toolchain"
   # 3. Compile the example with the target board and toolchain
-  # Note: This does not silence errors.
-  mbed-tools compile -t "$toolchain" -m "$board" >/dev/null || \
+  mbed-tools compile -t "$toolchain" -m "$board" || \
     fail "Failed to compile the example" "Please check the sources"
 
   # 4. Convert the output .elf executable to a .bin as it's what NRF52840_DK requires


### PR DESCRIPTION
There were a few changes missing in #3 that resulted in a failed CI workflow. Specifically, this was a result of not updating the paths in the scripts for both examples (after a rename of their folders in my fork). Also, the CI workflow was missing the `apt-get update` step, along with the `python3-venv` module.

Some of these have been addressed by @paul-szczepanek-arm. However, changes have been made to fix the paths for the "mcuboot" dependency folder in the mcuboot.sh script. The `/dev/null` redirects have been removed to provide a detailed build log and the CI workflow file has been restored to the one in my fork's main branch. 

> **Remarks**: These series of pull requests (and those in my own fork) have certainly taught me a great deal of the git discipline. It is the hope that I take these mistakes as lessons to learn from. 