### PR TITLE
Add support for DISCO_L475VG_IOT01A

### DIFF
--- a/MCUboot/README.md
+++ b/MCUboot/README.md
@@ -8,8 +8,6 @@ This demo application extends the [Mock](../Mock) example by including a bootloa
 
 To use the Python client, the host computer must have Bluetooth capabilities, either through an inbuilt chipset or via an external USB adapter.
 
-This application requires the [NRF52840_DK](https://os.mbed.com/platforms/Nordic-nRF52840-DK/) platform to run.
-
 You will also need the [GNU ARM Embedded](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm) toolchain and `python3` in your path to build the example.
 
 > **Important**: For macOS users, your terminal emulator would have to be granted access to Bluetooth through `System Preferences > Security & Privacy > Pirvacy > Bluetooth`. Click on the padlock to make changes and check the box next to your terminal app. If the app is missing from the menu, click on the `+` icon to add your terminal app to the list.
@@ -20,7 +18,7 @@ If you chose to auto-update the `application/mbed_app.json` file, then the [jq](
 
 To build the example, please run the following command from the repository root. To view more information on the steps involved in the build, please refer to the comments in [mcuboot.sh](../scripts/mcuboot.sh).
 ```shell
-./scripts/fota.sh -e=mcuboot
+./scripts/fota.sh -b=DISCO_L475VG_IOT01A -e=mcuboot --flash
 ```
 > **Note**: You can build the example without a connected target board. The script indicates the location of the factory firmware and the update binary. The factory firmware would have to be flashed manually when the target board is indeed connected later. The update binary would be used in the demonstration stage.
 

--- a/MCUboot/target/application/CMakeLists.txt
+++ b/MCUboot/target/application/CMakeLists.txt
@@ -1,0 +1,55 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Application
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(EXP_BLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os-experimental-ble-services CACHE INTERNAL "")
+set(MCUBOOT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mcuboot CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
+set(APP_TARGET application)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+project(${APP_TARGET})
+
+add_subdirectory(${MBED_PATH})
+add_subdirectory(${EXP_BLE_PATH}/services/FOTA)
+add_subdirectory(${MCUBOOT_PATH}/boot/bootutil/)
+add_subdirectory(${MCUBOOT_PATH}/boot/mbed/)  # Mbed-MCUboot Port
+
+include_directories(mbed-os-experimental-ble-services)
+
+add_executable(${APP_TARGET})
+
+project(${APP_TARGET})
+
+target_sources(${APP_TARGET}
+    PRIVATE
+        source/main.cpp
+        source/BlockDeviceFOTAEventHandler.h
+        source/BlockDeviceFOTAEventHandler.cpp
+        source/PeriodicBlockDeviceEraser.cpp
+        source/PeriodicBlockDeviceEraser.h
+)
+
+target_link_libraries(${APP_TARGET}
+    PUBLIC
+        mbed-os
+        mbed-ble
+    	bootutil
+        mbed-events
+    	mbed-mcuboot
+        mbed-storage
+        mbed-mbedtls
+        ble-service-fota
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+  set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/MCUboot/target/application/mbed-os.lib
+++ b/MCUboot/target/application/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/noonfom/mbed-os/#27160dbe0460ed5c898effbaf8881c39117ba505
+https://github.com/ARMmbed/mbed-os.git

--- a/MCUboot/target/application/mbed_app.json
+++ b/MCUboot/target/application/mbed_app.json
@@ -2,10 +2,16 @@
     "config": {
         "version-number": {
             "value": "\"0.1.0\""
+        },
+        "mbed_app_start": {
+            "help": "Use a custom application start address",
+            "macro_name": "MBED_APP_START",
+            "required": true
         }
     },
     "target_overrides": {
         "*": {
+	    "target.c_lib": "small", 
             "platform.stdio-convert-newlines": true,
             "platform.stdio-baud-rate": 115200,
             "mbed-trace.enable": true,
@@ -14,26 +20,24 @@
             "ble-api-implementation.max-characteristic-authorisation-count": 100
         },
         "DISCO_L475VG_IOT01A": {
+            "mbed_app_start": "0x8021000",
             "target.features_add": ["BLE"],
             "cordio.desired-att-mtu": 200,
             "cordio.rx-acl-buffer-size": 204,
-            "target.mbed_app_start": "0x8021000",
             "target.mbed_app_size": "0xBE000",
             "mcuboot.primary-slot-address": "0x8020000",
             "mcuboot.slot-size": "0xC0000",
             "mcuboot.scratch-address": "0x80E0000",
             "mcuboot.scratch-size": "0x20000",
-            "mcuboot.max-img-sectors": "0x180",
-            "mcuboot.read-granularity": 1,
-            "qspif.QSPI_MIN_PROG_SIZE": 1
+            "mcuboot.max-img-sectors": "0x180"
         },
         "NRF52840_DK": {
+            "mbed_app_start": "0x21000",
             "target.features_add": ["BLE"],
             "cordio.desired-att-mtu": 200,
             "cordio.rx-acl-buffer-size": 204,
             "cordio-ll.max-acl-size": 204,
             "cordio-nordic-ll.wsf-pool-buffer-size": 8192,
-            "target.mbed_app_start": "0x21000",
             "target.mbed_app_size": "0xBE000",
             "mcuboot.primary-slot-address": "0x20000",
             "mcuboot.slot-size": "0xC0000",

--- a/MCUboot/target/application/mcuboot.lib
+++ b/MCUboot/target/application/mcuboot.lib
@@ -1,1 +1,1 @@
-https://github.com/mcu-tools/mcuboot/
+https://github.com/lambda-shuttle/mcuboot.git

--- a/MCUboot/target/application/source/main.cpp
+++ b/MCUboot/target/application/source/main.cpp
@@ -27,7 +27,7 @@
 #include "platform/mbed_power_mgmt.h"
 #include "mbed-trace/mbed_trace.h"
 #include "bootutil/bootutil.h"
-#include "secondary_bd.h"
+#include "flash_map_backend/secondary_bd.h"
 
 #define TRACE_GROUP "MAIN"
 

--- a/MCUboot/target/bootloader/CMakeLists.txt
+++ b/MCUboot/target/bootloader/CMakeLists.txt
@@ -1,0 +1,43 @@
+# Copyright (c) 2021 ARM Limited. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Bootloader
+
+cmake_minimum_required(VERSION 3.19.0 FATAL_ERROR)
+
+set(MBED_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mbed-os CACHE INTERNAL "")
+set(MCUBOOT_PATH ${CMAKE_CURRENT_SOURCE_DIR}/mcuboot CACHE INTERNAL "")
+set(MBED_CONFIG_PATH ${CMAKE_CURRENT_BINARY_DIR} CACHE INTERNAL "")
+set(APP_TARGET bootloader)
+
+include(${MBED_PATH}/tools/cmake/app.cmake)
+
+project(${APP_TARGET})
+
+add_subdirectory(${MBED_PATH})
+add_subdirectory(${MCUBOOT_PATH}/boot/bootutil/)
+add_subdirectory(${MCUBOOT_PATH}/boot/mbed/)  # Mbed-MCUboot Port
+
+add_executable(${APP_TARGET})
+
+target_sources(${APP_TARGET}
+    PUBLIC
+        default_bd.cpp
+        signing_keys.c
+)
+
+target_link_libraries(${APP_TARGET}
+    PUBLIC
+        bootutil
+        mbed-mcuboot
+        mbed-storage-spif
+        mbed-storage-qspif
+        mbed-baremetal
+)
+
+mbed_set_post_build(${APP_TARGET})
+
+option(VERBOSE_BUILD "Have a verbose build process")
+if(VERBOSE_BUILD)
+    set(CMAKE_VERBOSE_MAKEFILE ON)
+endif()

--- a/MCUboot/target/bootloader/mbed-os.lib
+++ b/MCUboot/target/bootloader/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/noonfom/mbed-os/#27160dbe0460ed5c898effbaf8881c39117ba505
+https://github.com/ARMmbed/mbed-os.git

--- a/MCUboot/target/bootloader/mbed_app.json
+++ b/MCUboot/target/bootloader/mbed_app.json
@@ -10,6 +10,7 @@
         "*": {
             "target.restrict_size": "0x20000",
             "target.c_lib": "small",
+            "target.OUTPUT_EXT": "hex",
             "mcuboot.log-level": "MCUBOOT_LOG_LEVEL_DEBUG",
             "mbed-trace.enable": true,
             "mbed-trace.fea-ipv6": false
@@ -30,9 +31,7 @@
             "mcuboot.slot-size": "0xC0000",
             "mcuboot.scratch-address": "0x80E0000",
             "mcuboot.scratch-size": "0x20000",
-            "mcuboot.max-img-sectors": "0x180",
-            "mcuboot.read-granularity": 1,
-            "qspif.QSPI_MIN_PROG_SIZE": 1
+            "mcuboot.max-img-sectors": "0x180"
         }
     }
 }

--- a/MCUboot/target/bootloader/mcuboot.lib
+++ b/MCUboot/target/bootloader/mcuboot.lib
@@ -1,1 +1,1 @@
-https://github.com/mcu-tools/mcuboot/
+https://github.com/lambda-shuttle/mcuboot.git

--- a/Mock/README.md
+++ b/Mock/README.md
@@ -8,7 +8,7 @@ To verify the success of the transfer, the application computes the [SHA-256](ht
 
 ## Pre-requisites
 
-To use the Python client, the host computer must have Bluetooth capabilites, either through an inbuilt chipset or via an external USB adapter. This application requires the [NRF52840_DK](https://os.mbed.com/platforms/Nordic-nRF52840-DK/) platform to run; currently, the build tool only supports this platform. You will also need the [GNU ARM Embedded](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm) toolchain and `python3` in your path to build the example.
+To use the Python client, the host computer must have Bluetooth capabilites, either through an inbuilt chipset or via an external USB adapter. You will need the [GNU ARM Embedded](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm) toolchain and `python3` in your path to build the example.
 
 > **Important**: For macOS users, your terminal emulator would have to be granted access to Bluetooth through `System Preferences > Security & Privacy > Pirvacy > Bluetooth`. Click on the padlock to make changes and check the box next to your terminal app. If the app is missing from the menu, click on the `+` icon to add your terminal app to the list.
 
@@ -16,7 +16,7 @@ To use the Python client, the host computer must have Bluetooth capabilites, eit
 
 To build the example, please run the following command from the repository root. To view more information on the steps involved in the build, please refer to the comments in [mock.sh](../scripts/mock.sh).
 ```shell
-./scripts/fota.sh -e=mock
+./scripts/fota.sh -b=DISCO_L475VG_IOT01A -e=mock --flash
 ```
 > **Note**: You can build the example without a connected target board. The script indicates the location of the flash binary at the end of the build; this binary would have to be flashed manually when the target board is indeed connected later.
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ This repository houses example applications built for the Arm® Mbed™ OS platf
 The examples come with _batteries included!_ They're bundled with an automated build tool, "fota.sh", that eases the build process for the end-user. Please refer to the sections below for more information.
 
 ## Pre-requisites
-Currently, the only supported target board for the examples is the [`NRF52840_DK`](https://os.mbed.com/platforms/Nordic-nRF52840-DK/). The [BLE documentation](https://os.mbed.com/docs/mbed-os/v6.12/apis/ble.html) describes the BLE APIs available on Mbed™ OS; going through this documentation isn't strictly essential to run the examples, but is helpful in understanding the sources.
+Currently, the only supported target boards for the examples are the [`NRF52840_DK`](https://os.mbed.com/platforms/Nordic-nRF52840-DK/) and [`DISCO_L475VG_IOT01A`](https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/). The [BLE documentation](https://os.mbed.com/docs/mbed-os/v6.12/apis/ble.html) describes the BLE APIs available on Mbed™ OS; going through this documentation isn't strictly essential to run the examples, but is helpful in understanding the sources.
 
 ## Build Tool
 The `fota.sh` cli tool aids in setup and build of the examples in this repository. Please run `./scripts/fota.sh --help` for usage instructions.
 
-> **Note**: If the mount point is not provided (it could be the case that an end-user is trying to build without the board connected), then the target binary is not flashed. This is especially useful for building the examples with a CI workflow.
+> **Note**: If the `-f` or `--flash` option isn't provided (it could be the case that an end-user is trying to build without the board connected), then the target binary is not flashed. This is especially useful for building the examples with a CI workflow. Note that both flashing and erasing is acheived using `pyocd`.
 >
 > In the case of the MCUboot example, the _"factory firmware"_ is saved and would require manual transfer when the board is indeed connected. In either case, the demonstration step would be the only part that requires manual intervention from the user.
 >
-> **Important**: For now, the tool assumes the target board, toolchain, and example unless otherwise specified by the end-user. Currently, the only board and toolchain supported are `NRF52840_DK` and `GCC_ARM` respectively.
+> **Important**: The tool assumes the target board (`NRF52840_DK`), toolchain (`GCC_ARM`), and example (`mock`) unless otherwise specified by the end-user. Currently, only the `GCC_ARM` toolchain has been verified to work; the verification of functionality for binaries built using ARM Compiler 6 is pending.
 
 ## Examples
 
@@ -27,10 +27,10 @@ Please refer to the example-specific READMEs for build and demonstration instruc
 
 ## Known Issues
 
-1. **Dependency Conflicts**: The difference in version requirements of the [PyYAML](https://pyyaml.org) dependency imposed by both mbed-os and pyocd led to the creation of a temporary virtual environment; this is used in the "_creating and flashing the factory firmware_" stage of the MCUboot example build process. This is a known issue and would require changes to the `requirements.txt` file in the mbed-os to resolve.\
+1. **Dependency Conflicts**: The difference in version requirements of the [PyYAML](https://pyyaml.org) dependency imposed by both mbed-os and pyocd led to the creation of a temporary virtual environment (venv), which is used in the target binary flashing stage of both examples. This is a known issue and would require changes to the `requirements.txt` file in the mbed-os to resolve. Another conflict is that between pyocd and mbed-ls on the version requirement of [PrettyTable](https://pypi.org/project/prettytable/), which is resolved through the temporary venv. \
    \
-   Another minor conflict that doesn't hinder the build process is one between mbed-tools and mbed-os on the version requirement of the [Click](https://click.palletsprojects.com/en/8.0.x/) dependency; mbed-tools requires that the minimum version of Click to be greater than 7.1 while mbed-os requires it to be greater than 7.0. Now, the dependencies for mbed-os are installed after those of mbed-tools, which overwrites the newer version and generates a conflict. This would (again) require changes to the requirements file in the mbed-os repository to bump up the minimum version number of Click to 7.1.
-
+   Yet another minor conflict that doesn't hinder the build process is one between mbed-tools and mbed-os on the version requirement of the [Click](https://click.palletsprojects.com/en/8.0.x/) dependency; mbed-tools requires that the minimum version of Click to be greater than 7.1 while mbed-os requires it to be greater than 7.0. Now, the dependencies for mbed-os are installed after those of mbed-tools, which overwrites the newer version and generates a conflict. This would (again) require changes to the requirements file in the mbed-os repository to bump up the minimum version number of Click to 7.1.
+   
 2. **Target Binary Flashing**: For the Mock example, compiling with mbed-tools results in the following error:
     ```
     ERROR: Build program file (firmware) not found <path to mock example>/target/cmake_build/<target board>/develop/<toolchain>/target.hex
@@ -50,3 +50,5 @@ Mbed™ OS is an open-source, device software platform for the Internet of Thing
 * [mbed-os-example-ble](https://github.com/ARMmbed/mbed-os-example-ble)
 * [mbed-os-experimental-ble-services](https://github.com/ARMmbed/mbed-os-experimental-ble-services)
 * [mcuboot](https://github.com/mcu-tools/mcuboot)
+* [mbed-mcuboot-demo](https://github.com/AGlass0fMilk/mbed-mcuboot-demo)
+* [mbed-mcuboot-blinky](https://github.com/AGlass0fMilk/mbed-mcuboot-blinky)

--- a/scripts/fota.sh
+++ b/scripts/fota.sh
@@ -15,14 +15,14 @@
 
 # Author's Note:
 # The fota cli tool is used to setup and build the ble fota examples in this repository. The tool takes in as
-# arguments the example, target board, mount point of the target board, and toolchain. Note that if the mount point
-# is not provided (it could be the case that an end-user is trying to build without the board connected), then the
-# target binary is not flashed. In the case of the MCUboot example, the "factory firmware" is saved and would require
-# manual transfer when the board is indeed connected. In either case, the demonstration step would be the only part
-# that requires manual intervention.
+# arguments the example, target board and toolchain. Note that if the flash option is not provided (it could be the case
+# that an end-user is trying to build without the board connected), then the target binary is not flashed. In the case 
+# of the MCUboot example, the "factory firmware" is saved and would require manual transfer when the board is indeed 
+# connected. In either case, the demonstration step would be the only part that requires manual intervention.
 #
 # Important: The tool assumes the target board and toolchain unless otherwise specified by the end-user. However,
-#            currently, the only board and toolchain supported are NRF52840_DK and GCC_ARM respectively.
+#            currently, the only boards and toolchain supported are NRF52840_DK and DISCO_L475VG_IOT01A and GCC_ARM 
+#            respectively.
 
 set -e
 trap 'cleanup $?' SIGINT SIGTERM ERR EXIT
@@ -46,28 +46,15 @@ Options:
                                   [default: GCC_ARM]
   -b=, --board=TEXT               A build target for an Mbed-enabled device.
                                   [default: NRF52840_DK]
-  -m=, --mount=TEXT               Path to the mount point of the target board.
+  -f, --flash                     Flash the connected target board
   -c, --clean                     Clean the example builds and environment
   -h, --help                      Print this message and exit
 
 Note:
-  For now, only the NRF52840_DK board and GCC_ARM toolchain are supported. Also,
-  if a mount point isn't provided, then the target binary is not flashed.
+  For now, only the NRF52840_DK and DISCO_L475VG_IOT01A boards and GCC_ARM 
+  toolchain are supported. Please connect only one target board when flashing. 
 EOF
   exit
-}
-
-# This function would clean up the example builds and generated files
-clean () {
-  log message "Cleaning builds and generated files..."
-  
-  rm -rf "$root/venv"
-
-  # Clean example-specific files and folders
-  mock_clean "$root"
-  mcuboot_clean "$root"
-
-  log success "All neat and tidy now" && exit
 }
 
 # Parses the options specified by the end-user and either assigns the corresponding variable or calls a function and
@@ -79,25 +66,12 @@ parse_options () {
       -e=*|--example=*)   example="${i#*=}"   ; shift  ;;
       -t=*|--toolchain=*) toolchain="${i#*=}" ; shift  ;;
       -b=*|--board=*)     board="${i#*=}"     ; shift  ;;
-      -m=*|--mount=*)     mount="${i#*=}"     ; shift  ;;
-      -c|--clean)         clean               ;;
+      -f|--flash)         skip=0              ; shift  ;;
+      -c|--clean)         clean=1             ;;
       -h|--help)          usage               ;;
       *)                  return 1            ;;
     esac
   done
-}
-
-# Check that the provided target board mount point is valid. If the mount point is not provided, display a short message
-# indicating that binaries will have to be flashed manually.
-valid_mount () {
-  if [[ -z $mount ]]; then
-    log note "Mount point not provided - binaries will not be flashed."
-    skip=1
-  else
-    [ -d "$mount" ] || fail "Mount point invalid" \
-                                 "Please check the path and if the board is connected" \
-                                 "Tip: Use mbed-ls to identify the mount point path"
-  fi
 }
 
 # Checks if the example is either mock or mcuboot. If more examples, are added in the future, this function would have
@@ -114,7 +88,8 @@ valid_example () {
 valid_board () {
   case $board in
     NRF52840_DK) ;;
-    *) fail "Unsupported board" "The only supported board is NRF52840_DK"
+    DISCO_L475VG_IOT01A) ;;
+    *) fail "Unsupported board" "The only supported boards are NRF52840_DK and DISCO_L475VG_IOT01A"
   esac
 }
 
@@ -128,13 +103,12 @@ valid_toolchain () {
 
 # A series of checks to make sure that the program options are valid
 check_usage () {
-  valid_mount
   valid_example
   valid_board
   valid_toolchain
 }
 
-# Setups up the main virtual environment and activates it
+# Sets up the main virtual environment and activates it
 setup_virtualenv () {
   if [[ -d venv ]]; then
     log message "Using existing virtual environment venv..."
@@ -162,17 +136,27 @@ install_requirements () {
 # Call the build functions corresponding to the selected example
 # Pre: The example is valid and so are all other arguments.
 build_example () {
-  args=("$toolchain" "$board" "$mount" "$skip" "$root")
+  args=("$toolchain" "$board" "$skip" "$root")
   case $example in
     mock)    mock_build "${args[@]}"    ;;
     mcuboot) mcuboot_build "${args[@]}" ;;
   esac
 }
 
-# Cleanup routine that runs when the program exits (either successfully or abruptly)
+# This function would clean up the example builds and generated files; the routine runs when the program exits (etiher
+# successfully or abruptly)
 cleanup () {
-  # If unsuccessful termination, then clean the build
-  if [[ "$1" -eq 1 ]]; then clean; fi
+  if [[ "$clean" -eq 1 ]]; then
+    log message "Cleaning builds and generated files..."
+  
+    rm -rf "$root/venv"
+
+    # Clean example-specific files and folders
+    mock_clean "$root"
+    mcuboot_clean "$root"
+
+    log success "All neat and tidy now" && exit
+  fi
 }
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -183,7 +167,8 @@ main () {
   example="mock"
   toolchain="GCC_ARM"
   board="NRF52840_DK"
-  skip=0               # Skip the binary flashing if mount point is missing - Default: false
+  skip=1               # Skip the binary flashing if the -f or --flash is missing - Default: true
+  clean=0              # Clean the build files and dependencies - Default: false
 
   # Root directory of repository
   root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &>/dev/null && pwd -P)

--- a/scripts/fota.sh
+++ b/scripts/fota.sh
@@ -59,7 +59,7 @@ EOF
 
 # This function would clean up the example builds and generated files
 clean () {
-  say message "Cleaning builds and generated files..."
+  log message "Cleaning builds and generated files..."
   
   rm -rf "$root/venv"
 
@@ -67,7 +67,7 @@ clean () {
   mock_clean "$root"
   mcuboot_clean "$root"
 
-  say success "All neat and tidy now" && exit
+  log success "All neat and tidy now" && exit
 }
 
 # Parses the options specified by the end-user and either assigns the corresponding variable or calls a function and
@@ -91,7 +91,7 @@ parse_options () {
 # indicating that binaries will have to be flashed manually.
 valid_mount () {
   if [[ -z $mount ]]; then
-    say note "Mount point not provided - binaries will not be flashed."
+    log note "Mount point not provided - binaries will not be flashed."
     skip=1
   else
     [ -d "$mount" ] || fail "Mount point invalid" \
@@ -137,9 +137,9 @@ check_usage () {
 # Setups up the main virtual environment and activates it
 setup_virtualenv () {
   if [[ -d venv ]]; then
-    say message "Using existing virtual environment venv..."
+    log message "Using existing virtual environment venv..."
   else
-    say message "Creating virtual environment..."
+    log message "Creating virtual environment..."
 
     # Create the venv directory and setup the virtual environment
     # shellcheck disable=SC2015
@@ -147,16 +147,16 @@ setup_virtualenv () {
       || fail "Virtual environment creation failed!" "Tip: Check your python installation!"
   fi
   source venv/bin/activate
-  say success "Virtual environment activated"
+  log success "Virtual environment activated"
 }
 
 # Installs the required python dependencies silently and notify if there's any issue in the installation.
 install_requirements () {
-  say message "Installing/updating requirements silently..."
+  log message "Installing/updating requirements silently..."
   # shellcheck disable=SC2015
   pip install -q --upgrade pip && pip install -q -r "$root/requirements.txt" \
     || fail "Unable to install requirements!" "Please take a look at requirements.txt"
-  say success "General requirements installed/updated"
+  log success "General requirements installed/updated"
 }
 
 # Call the build functions corresponding to the selected example

--- a/scripts/fota.sh
+++ b/scripts/fota.sh
@@ -25,7 +25,6 @@
 #            respectively.
 
 set -e
-trap 'cleanup $?' SIGINT SIGTERM ERR EXIT
 
 source scripts/utils.sh
 source scripts/mock.sh
@@ -67,7 +66,7 @@ parse_options () {
       -t=*|--toolchain=*) toolchain="${i#*=}" ; shift  ;;
       -b=*|--board=*)     board="${i#*=}"     ; shift  ;;
       -f|--flash)         skip=0              ; shift  ;;
-      -c|--clean)         clean=1             ;;
+      -c|--clean)         cleanup             ;;
       -h|--help)          usage               ;;
       *)                  return 1            ;;
     esac
@@ -143,20 +142,17 @@ build_example () {
   esac
 }
 
-# This function would clean up the example builds and generated files; the routine runs when the program exits (etiher
-# successfully or abruptly)
+# This function would clean up the example builds and generated files; the routine runs when -c or --clean is passed
 cleanup () {
-  if [[ "$clean" -eq 1 ]]; then
-    log message "Cleaning builds and generated files..."
-  
-    rm -rf "$root/venv"
+  log message "Cleaning builds and generated files..."
 
-    # Clean example-specific files and folders
-    mock_clean "$root"
-    mcuboot_clean "$root"
+  rm -rf "$root/venv"
 
-    log success "All neat and tidy now" && exit
-  fi
+  # Clean example-specific files and folders
+  mock_clean "$root"
+  mcuboot_clean "$root"
+
+  log success "All neat and tidy now" && exit
 }
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -168,7 +164,6 @@ main () {
   toolchain="GCC_ARM"
   board="NRF52840_DK"
   skip=1               # Skip the binary flashing if the -f or --flash is missing - Default: true
-  clean=0              # Clean the build files and dependencies - Default: false
 
   # Root directory of repository
   root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &>/dev/null && pwd -P)

--- a/scripts/mcuboot.sh
+++ b/scripts/mcuboot.sh
@@ -131,7 +131,7 @@ mcuboot_build () {
 
   # 14. Flash the board with the binary (if skip is 0)
   if [[ "$skip" -eq 0 ]]; then
-    pyocd erase --chip && pyocd flash merged.hex || \
+    pyocd erase --chip --connect under-reset  && pyocd flash --connect under-reset merged.hex || \
       fail "Unable to flash firmware!" "Please ensure the board is connected"
     log success "Factory firmware flashed"
   else
@@ -194,10 +194,10 @@ mcuboot_clean () {
 
   # Remove generated files and folders in bootloader folder
   rm -rf "$bootloader"/sign* "$bootloader/application.hex" "$bootloader/merged.hex"
-  rm -rf "$bootloader/cmake_build" "$bootloader/dist" "$bootloader/imgtool.egg-info"
+  rm -rf "$bootloader/cmake_build" "$bootloader/dist" "$bootloader/imgtool.egg-info" "$bootloader/build"
 
   # Remove bootloader dependencies
-  rm -rf "$bootloader/mbed-os" "$bootloader/mcuboot"
+  rm -rf "$bootloader/mbed-os" "$bootloader/mcuboot" "$bootloader/venv"
 
   # Remove application build folder and dependencies
   rm -rf "$application/cmake_build" "$application/mbed-os" "$application/mbed-os-experimental-ble-services" "$application/mcuboot"

--- a/scripts/mcuboot.sh
+++ b/scripts/mcuboot.sh
@@ -26,11 +26,11 @@ prompt_auto_update () {
   done
 }
 
-# Builds the mcuboot example and flashes the binaries if a mount is provided.
+# Builds the mcuboot example and flashes the binaries if -f or --flash is provided
 # Please refer to the commented steps for more information
 # Pre: Arguments passed here are all valid
 mcuboot_build () {
-  toolchain=$1; board=$2; mount=$3; skip=$4; root=$5
+  toolchain=$1; board=$2; skip=$3; root=$4
 
   # Paths to application and bootloader
   application=$root/MCUboot/target/application
@@ -41,13 +41,13 @@ mcuboot_build () {
   # shellcheck disable=SC2015
   cd "$application" && mbed-tools deploy || \
     fail "Unable to install application dependencies" \
-              "Please check mcuboot.lib, mbed-os.lib, and mbed-os-experimental-ble-services.lib"
+         "Please check mcuboot.lib, mbed-os.lib, and mbed-os-experimental-ble-services.lib"
 
   # 2. Install bootloader dependencies
   # shellcheck disable=SC2015
   cd "$bootloader" && mbed-tools deploy || \
     fail "Unable to install bootloader dependencies" \
-              "Please check mcuboot.lib and mbed-os.lib"
+         "Please check mcuboot.lib and mbed-os.lib"
 
   # 3. Install mbed-os python dependencies (silently)
   pip install -q -r mbed-os/requirements.txt || \
@@ -75,24 +75,25 @@ mcuboot_build () {
     mcuboot/scripts/imgtool.py getpub -k signing-keys.pem >> signing_keys.c || \
       fail "Unable to create the signing keys"
 
-  # 7. Build the bootloader using the old mbed-cli
+  # 7. Build the bootloader using mbed-tools
   # Note: This does not silence errors
-  mbed compile -t "$toolchain" -m "$board" || \
+  mbed-tools compile -t "$toolchain" -m "$board" || \
     fail "Failed to compile the bootloader" "Please check the sources"
 
   log success "Created signing keys and built the bootloader"
   log message "Building and signing the primary application..."
 
-  # 8. Build the primary application using the old mbed-cli
-  # shellcheck disable=SC2015
-  cd "$application" && mbed compile -t "$toolchain" -m "$board" || \
+  # 8. Build the primary application using mbed-tools
+  # shellcheck disable=SC2015  
+  out="cmake_build/$board/develop/$toolchain"
+  cd "$application" && mbed-tools compile -t "$toolchain" -m "$board" || \
     fail "Failed to compile the bootloader" "Please check the sources"
 
   # shellcheck disable=SC2015
-  cp "BUILD/$board/$toolchain/application.hex" "$bootloader" && cd "$bootloader" && \
+  cp "$out/application.hex" "$bootloader" && cd "$bootloader" && \
     mcuboot/scripts/imgtool.py sign -k signing-keys.pem \
     --align 4 -v 0.1.0 --header-size 4096 --pad-header -S 0xC0000 \
-    --pad application.hex signed_application.hex || \
+    application.hex signed_application.hex || \
       fail "Unable to sign the primary application"
 
   log success "Built and signed the primary application"
@@ -125,12 +126,12 @@ mcuboot_build () {
   log success "Requirements installed/updated"
 
   # 13. Create the factory firmware
-  hexmerge.py -o merged.hex --no-start-addr "BUILD/$board/$toolchain/bootloader.hex" signed_application.hex || \
+  hexmerge.py -o merged.hex --no-start-addr "$out/bootloader.hex" signed_application.hex || \
     fail "Unable to create factory firmware"
 
   # 14. Flash the board with the binary (if skip is 0)
   if [[ "$skip" -eq 0 ]]; then
-    pyocd erase --chip && cp merged.hex "$mount" \\
+    pyocd erase --chip && pyocd flash merged.hex || \
       fail "Unable to flash firmware!" "Please ensure the board is connected"
     log success "Factory firmware flashed"
   else
@@ -167,11 +168,11 @@ mcuboot_build () {
   log message "Creating the update binary..."
 
   # shellcheck disable=SC2015
-  cd "$application" && mbed compile -t "$toolchain" -m "$board" || \
+  cd "$application" && mbed-tools compile -t "$toolchain" -m "$board" || \
     fail "Failed to compile the application" "Please check the sources"
 
   # shellcheck disable=SC2015
-  cp "BUILD/$board/$toolchain/application.hex" "$bootloader" && cd "$bootloader" && \
+  cp "$out/application.hex" "$bootloader" && cd "$bootloader" && \
     mcuboot/scripts/imgtool.py sign -k signing-keys.pem \
     --align 4 -v 0.1.1 --header-size 4096 --pad-header -S 0x55000 \
     application.hex signed_update.hex || \
@@ -193,11 +194,11 @@ mcuboot_clean () {
 
   # Remove generated files and folders in bootloader folder
   rm -rf "$bootloader"/sign* "$bootloader/application.hex" "$bootloader/merged.hex"
-  rm -rf "$bootloader/build" "$bootloader/dist" "$bootloader/imgtool.egg-info"
+  rm -rf "$bootloader/cmake_build" "$bootloader/dist" "$bootloader/imgtool.egg-info"
 
   # Remove bootloader dependencies
   rm -rf "$bootloader/mbed-os" "$bootloader/mcuboot"
 
   # Remove application build folder and dependencies
-  rm -rf "$application/BUILD" "$application/mbed-os" "$application/mbed-os-experimental-ble-services" "$application/mcuboot"
+  rm -rf "$application/cmake_build" "$application/mbed-os" "$application/mbed-os-experimental-ble-services" "$application/mcuboot"
 }

--- a/scripts/mock.sh
+++ b/scripts/mock.sh
@@ -74,7 +74,7 @@ mock_build () {
     log success "Requirements installed/updated"
 
     # 5E. Flash the board with the binary
-    pyocd flash "$out/BLE_GattServer_FOTAService.bin" || \
+    pyocd erase --chip --connect under-reset && pyocd flash --connect under-reset "$out/BLE_GattServer_FOTAService.bin" || \
       fail "Unable to flash binary!" "Please ensure the board is connected"
     log success "Binary flashed"
 

--- a/scripts/mock.sh
+++ b/scripts/mock.sh
@@ -15,11 +15,11 @@
 
 source scripts/utils.sh
 
-# Builds the mock example and flashes the binary if a mount point is provided
+# Builds the mock example and flashes the binary if -f or --flash is provided
 # Please refer to the commented steps for more information
 # Pre: Arguments passed here are all valid
 mock_build () {
-  toolchain=$1; board=$2; mount=$3; skip=$4; root=$5
+  toolchain=$1; board=$2; skip=$3; root=$4
 
   log message "Installing/updating example-specific dependencies..."
   # 1. Install mbed-os and mbed-os experimental-ble-services
@@ -46,15 +46,44 @@ mock_build () {
   arm-none-eabi-objcopy -O binary "$out/BLE_GattServer_FOTAService.elf" "$out/BLE_GattServer_FOTAService.bin" || \
     fail "Failed to extract binary from elf" "Tip: Check if arm-none-eabi-objcopy is in your path"
 
-  # 5. Flash the board with the binary (if skip is 0)
+  # 5. Setup and flash if skip is 0
   # shellcheck disable=SC2015
   if [[ "$skip" -eq 0 ]]; then
-    cp "$out/BLE_GattServer_FOTAService.bin" "$mount" || \
+
+    # 5A. Deactivate the primary virtual environment
+    deactivate
+
+    log message "Creating temporary virtual environment..."
+
+    # 5B. Create a new, temporary virtual environment just for pyocd
+    # shellcheck disable=SC2015
+    mkdir venv && python3 -m venv venv || \
+      fail "Virtual environment creation failed!" "Tip: Check your python installation!"
+
+    # 5C. Activate temporary virtual environment
+    source venv/bin/activate
+
+    log success "Temporary virtual environment activated"
+    log message "Installing requirements (pyocd) silently..."
+
+    # 5D. Install requirements (pyocd and intelhex) for temporary environment (silently)
+    # shellcheck disable=SC2015
+    pip install -q --upgrade pip && pip install -q pyocd==0.30.3 || \
+      fail "Unable to install temporary venv requirements" "Please check scripts/mock.sh"
+
+    log success "Requirements installed/updated"
+
+    # 5E. Flash the board with the binary
+    pyocd flash "$out/BLE_GattServer_FOTAService.bin" || \
       fail "Unable to flash binary!" "Please ensure the board is connected"
     log success "Binary flashed"
+
+    # 5F. Deactivate and restore virtual environment
+    deactivate && rm -rf venv && source "$root/venv/bin/activate"
   else
     log message "Binary at $root/Mock/target/$out/BLE_GattServer_FOTAService.bin"
   fi
+
 
   log success "Build Complete" "Please refer to the documentation for demonstration instructions"
 }

--- a/scripts/mock.sh
+++ b/scripts/mock.sh
@@ -21,7 +21,7 @@ source scripts/utils.sh
 mock_build () {
   toolchain=$1; board=$2; mount=$3; skip=$4; root=$5
 
-  say message "Installing/updating example-specific dependencies..."
+  log message "Installing/updating example-specific dependencies..."
   # 1. Install mbed-os and mbed-os experimental-ble-services
   # shellcheck disable=SC2015
   cd "$root/Mock/target" && mbed-tools deploy || \
@@ -32,10 +32,10 @@ mock_build () {
     fail "Unable to install mbed-os requirements" "Please take a look at mbed-os/requirements.txt"
 
   # A short message addressing the known Click dependency conflict - this should be removed once resolved.
-  say note "Click dependency conflict" \
+  log note "Click dependency conflict" \
            "This is a known issue and does not hinder the build process" \
            "Refer to the documentation for more information"
-  say success "Example requirements installed/updated"
+  log success "Example requirements installed/updated"
 
   out="cmake_build/$board/develop/$toolchain"
   # 3. Compile the example with the target board and toolchain
@@ -51,12 +51,12 @@ mock_build () {
   if [[ "$skip" -eq 0 ]]; then
     cp "$out/BLE_GattServer_FOTAService.bin" "$mount" || \
       fail "Unable to flash binary!" "Please ensure the board is connected"
-    say success "Binary flashed"
+    log success "Binary flashed"
   else
-    say message "Binary at $root/Mock/target/$out/BLE_GattServer_FOTAService.bin"
+    log message "Binary at $root/Mock/target/$out/BLE_GattServer_FOTAService.bin"
   fi
 
-  say success "Build Complete" "Please refer to the documentation for demonstration instructions"
+  log success "Build Complete" "Please refer to the documentation for demonstration instructions"
 }
 
 # Clean build files and dependencies specific to this example

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -27,7 +27,7 @@ setup_formatting () {
 }
 
 # Says (i.e. prints) a message to the console with formatting based on the selected formatting mode.
-say () {
+log () {
   case $1 in
     error)
       # The first line of the message is treated as the message heading and is marked in bold red along with an "ERROR:"
@@ -60,6 +60,6 @@ say () {
 
 # Prints an error message to stderr and exits (or returns) with a code of 1
 fail () {
-  say error "$@"
+  log error "$@"
   exit 1
 }


### PR DESCRIPTION
Currently, the script for building the MCUboot example, `mcuboot.sh`, uses the old mbed-cli (V1) to build the bootloader and primary application as the [MCUboot port for Mbed OS](https://mcu-tools.github.io/mcuboot/readme-mbed.html) lacks support for the new `mbed-tools` and was built right before the transition. The [Mock example](https://github.com/lambda-shuttle/mbed-os-example-ble-fota/tree/cmake-support/Mock), however, uses `mbed-tools`.

> **Note**: `mbed-tools` is also known as Mbed CLI 2. This new tool makes use of _"Ninja as a build system, and CMake to generate the build environment and manage the build process in a compiler-independent manner."_ More information can be found [here](https://os.mbed.com/docs/mbed-os/v6.12/build-tools/mbed-cli-2.html). 

A pull request has been issued at mcu-tools/mcuboot#1153 to add support for CMake; work on this wasn't trivial and involved generous help from @LDong-Arm to resolve. The library information file for the MCUboot example now points to this [fork](https://github.com/lambda-shuttle/mcuboot). Subsequently, CMakeLists.txt files were added to the bootloader and application directories of the MCUboot FOTA example to facilitate the mbed-tools build workflow. 

This added support for CMake also saw a number of smaller changes (resolving header paths and updating the app configuration json file). The `mcuboot.sh` script was updated to use `mbed-tools` and README.md files for both the repository and examples were updated accordingly. The examples have been verified to work as expected on `DISCO_L475VG_IOT01A`.

Other notable changes include the use of `pyocd` for flashing the binaries, with the script now accepting a `-f` or `--flash` option instead of the board's mount point, and an updated clean routine that only cleans the builds and generated files when specified to do so; previously, the dependencies and generated files were automatically cleaned on a failed exit.